### PR TITLE
Adds a line decoration to <summary> elements

### DIFF
--- a/_includes/style.css
+++ b/_includes/style.css
@@ -129,6 +129,18 @@ details>summary::before{
   margin-top: 0.20rem;
 }
 
+details>summary>h3:hover {
+  text-decoration: underline;
+  text-decoration-style: dashed;
+  text-decoration-color: #660033;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 0.1em;
+}
+
+details.viewed>summary>h3:hover {
+  text-decoration-color: #66003344;
+}
+
 details[data-syndicated="1"][data-day="yesterday"]>summary::before{
   content: "❖";
 }


### PR DESCRIPTION
Adds a line decoration on hover to make it slightly clearer that it's clickable/interactable.

<img width="598" alt="image" src="https://github.com/captn3m0/news/assets/3104454/b7a5437d-dbeb-4518-9022-e6d5cb3ce7a6">
<img width="605" alt="image" src="https://github.com/captn3m0/news/assets/3104454/03e238c0-fca9-45eb-898a-f2fc70bc5ca7">


